### PR TITLE
Split HiC + normalization

### DIFF
--- a/config/cluster.yaml
+++ b/config/cluster.yaml
@@ -19,7 +19,17 @@ mergedSort:
   memPerCpu: 8G
 
 hic:
-  memPerCpu: 16G
+  memPerCpu: 260G
+  time: 10080
 
 hic30:
-  memPerCpu: 16G
+  memPerCpu: 260G
+  time: 10080
+  
+norm:
+  memPerCpu: 260G
+  time: 10080
+  
+norm30:
+  memPerCpu: 260G
+  time: 10080

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,5 +16,8 @@ ligation: "GATCGATC"
 ## Set splitsize
 splitsize: 200000000 ## 200000000 good default (50M reads/file) (i.e. 4000000 = 1M reads/file) 
 
+## Java memory for buildHiC (hic/norm rules)
+javaMem: "250880"
+
 ## Additional options
 mapq0_reads_included: 0

--- a/scripts/juicer_tools
+++ b/scripts/juicer_tools
@@ -24,18 +24,18 @@
 if [ "$CALLEDBY" = "AWS" ]
 then
     echo "AWS"
-    java -Djava.io.tmpdir=/opt/juicer/tmp -Djava.awt.headless=true -Djava.library.path=`dirname $0`/lib64  -Xmx32000m -Xms8000m -jar `dirname $0`/juicer_tools.7.0.jar $*
+    java -Djava.io.tmpdir=/opt/juicer/tmp -Djava.awt.headless=true -Djava.library.path=`dirname $0`/lib64  -Xmx32000m -Xms8000m -jar `dirname $0`/juicer_tools.jar $*
 elif [ "$CALLEDBY" = "UGER" ]
 then
     echo "UGER"
-    java -Djava.awt.headless=true  -Xmx16000m  -jar `dirname $0`/juicer_tools.7.5.jar  $*
+    java -Djava.awt.headless=true  -Xmx16000m  -jar `dirname $0`/juicer_tools.jar  $*
 elif [ "$CALLEDBY" = "SLURM" ]
 then
     echo "SLURM"
-    java -Djava.awt.headless=true -Djava.library.path=`dirname $0`/lib64 -Xmx16000m -Xms16000m -Xgcthreads1 -jar `dirname $0`/juicer_tools.7.5.jar $*
+    java -Djava.awt.headless=true -Djava.library.path=`dirname $0`/lib64 -Xmx16000m -Xms16000m -Xgcthreads1 -jar `dirname $0`/juicer_tools.jar $*
 elif [ "$CALLEDBY" = "LSF" ] 
 then
-    java -Djava.awt.headless=true -Djava.library.path=`dirname $0`/lib64 -Xmx16000m -Xms16000m -Xgcthreads1 -jar `dirname $0`/juicer_tools.7.0.jar $*
+    java -Djava.awt.headless=true -Djava.library.path=`dirname $0`/lib64 -Xmx16000m -Xms16000m -Xgcthreads1 -jar `dirname $0`/juicer_tools.jar $*
 else # default, don't use temp directory or gpus, use CUDA 7.0
     java -Djava.awt.headless=true  -Xmx16000m  -jar `dirname $0`/juicer_tools.jar  $*
 fi

--- a/workflows/alignFASTQ
+++ b/workflows/alignFASTQ
@@ -288,11 +288,11 @@ rule hic:
         'output/{group}/benchmarks/{group}_hic.tsv'
     params:
         chromSizes = config['chromSizes'],
-	    javaMem = config['javaMem']
+        javaMem = config['javaMem']
     threads: 1
     shell:
         """
-	    export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
         java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar pre -n -s {input.inter} -g {input.hists} -q 1 {input.merged_nodups} {output.hic} {params.chromSizes} 1> {log.out} 2> {log.err}
         """
         
@@ -311,11 +311,11 @@ rule hic30:
         'output/{group}/benchmarks/{group}_hic30.tsv'
     params:
         chromSizes = config['chromSizes'],
-	    javaMem = config['javaMem']
+        javaMem = config['javaMem']
     threads: 1
     shell:
         """
-	    export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
         java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar pre -n -s {input.inter30} -g {input.hists30} -q 30 {input.merged_nodups} {output.hic30} {params.chromSizes} 1> {log.out} 2> {log.err}
         """
         
@@ -334,9 +334,9 @@ rule norm:
     threads: 1
     shell:
         """
-	    export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
         java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic} 1> {log.out} 2> {log.err}
-	    touch {output.done}
+        touch {output.done}
         """
 	
 rule norm30:
@@ -354,9 +354,9 @@ rule norm30:
     threads: 1
     shell:
         """
-	    export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
         java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic} 1> {log.out} 2> {log.err}
-	    touch {output.done}
+        touch {output.done}
         """
         
 rule compress:

--- a/workflows/alignFASTQ
+++ b/workflows/alignFASTQ
@@ -272,7 +272,7 @@ rule inter30:
         ./scripts/juicer_tools LibraryComplexity $(wc -l < {input.merged_nodups}) $(wc -l < {input.dups}) $(wc -l < {input.optdups}) >> {output.inter30} 2>> {log.err}
         ./scripts/statistics.pl -s {params.site_file} -l {params.ligation} -o {output.inter30} -q 30 {input.merged_nodups} 2>> {log.err}
         """
-
+        
 rule hic:
     input:
         done = rules.dedup.output.done,
@@ -284,16 +284,18 @@ rule hic:
     log:
         err = 'output/{group}/logs/{group}_hic.err',
         out = 'output/{group}/logs/{group}_hic.out'
-    params:
-        chromSizes = config['chromSizes']
-    threads: 1
     benchmark:
         'output/{group}/benchmarks/{group}_hic.tsv'
+    params:
+        chromSizes = config['chromSizes'],
+	    javaMem = config['javaMem']
+    threads: 1
     shell:
         """
-        ./scripts/juicer_tools pre -s {input.inter} -g {input.hists} -q 1 {input.merged_nodups} {output.hic} {params.chromSizes} 1> {log.out} 2> {log.err}
+	    export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar pre -n -s {input.inter} -g {input.hists} -q 1 {input.merged_nodups} {output.hic} {params.chromSizes} 1> {log.out} 2> {log.err}
         """
-
+        
 rule hic30:
     input:
         done = rules.dedup.output.done,
@@ -305,21 +307,65 @@ rule hic30:
     log:
         err = 'output/{group}/logs/{group}_hic30.err',
         out = 'output/{group}/logs/{group}_hic30.out'
-    params:
-        chromSizes = config['chromSizes']
-    threads: 1
     benchmark:
         'output/{group}/benchmarks/{group}_hic30.tsv'
+    params:
+        chromSizes = config['chromSizes'],
+	    javaMem = config['javaMem']
+    threads: 1
     shell:
         """
-        ./scripts/juicer_tools pre -s {input.inter30} -g {input.hists30} -q 30 {input.merged_nodups} {output.hic30} {params.chromSizes} 1> {log.out} 2> {log.err}
+	    export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar pre -n -s {input.inter30} -g {input.hists30} -q 30 {input.merged_nodups} {output.hic30} {params.chromSizes} 1> {log.out} 2> {log.err}
         """
-
+        
+rule norm:
+    input:
+        hic = rules.hic.output.hic
+    output:
+        done = 'output/{group}/{group}_norm_done.txt'
+    log:
+        err = 'output/{group}/logs/{group}_norm.err',
+        out = 'output/{group}/logs/{group}_norm.out'
+    benchmark:
+        'output/{group}/benchmarks/{group}_norm.tsv'
+    params:
+        javaMem = config['javaMem']
+    threads: 1
+    shell:
+        """
+	    export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic} 1> {log.out} 2> {log.err}
+	    touch {output.done}
+        """
+	
+rule norm30:
+    input:
+        hic30 = rules.hic30.output.hic30
+    output:
+        done = 'output/{group}/{group}_norm30_done.txt'
+    log:
+        err = 'output/{group}/logs/{group}_norm30.err',
+        out = 'output/{group}/logs/{group}_norm30.out'
+    benchmark:
+        'output/{group}/benchmarks/{group}_norm.tsv'
+    params:
+        javaMem = config['javaMem']
+    threads: 1
+    shell:
+        """
+	    export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic} 1> {log.out} 2> {log.err}
+	    touch {output.done}
+        """
+        
 rule compress:
     input:
         done = rules.dedup.output.done,
         hic = rules.hic.output.hic, 
         hic30 = rules.hic30.output.hic30,
+        norm = rules.norm.output.done,
+        norm30 = rules.norm30.output.done,
         merged_nodups = rules.dedup.output.merged_nodups
     output:
         'output/{group}/{group}_dedup_merged_nodups.txt.gz'

--- a/workflows/alignFASTQ
+++ b/workflows/alignFASTQ
@@ -355,7 +355,7 @@ rule norm30:
     shell:
         """
         export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
-        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic} 1> {log.out} 2> {log.err}
+        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic30} 1> {log.out} 2> {log.err}
         touch {output.done}
         """
         

--- a/workflows/buildHIC
+++ b/workflows/buildHIC
@@ -128,11 +128,11 @@ rule hic:
         'output/{group}/benchmarks/{group}_hic.tsv'
     params:
         chromSizes = config['chromSizes'],
-	javaMem = config['javaMem']
+        javaMem = config['javaMem']
     threads: 1
     shell:
         """
-	export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
         java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar pre -n -s {input.inter} -g {input.hists} -q 1 {input.merged_nodups} {output.hic} {params.chromSizes} 1> {log.out} 2> {log.err}
         """
 
@@ -153,11 +153,11 @@ rule hic30:
         'output/{group}/benchmarks/{group}_hic30.tsv'
     params:
         chromSizes = config['chromSizes'],
-	javaMem = config['javaMem']
+        javaMem = config['javaMem']
     threads: 1
     shell:
         """
-	export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
         java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar pre -n -s {input.inter30} -g {input.hists30} -q 30 {input.merged_nodups} {output.hic30} {params.chromSizes} 1> {log.out} 2> {log.err}
         """
 	
@@ -177,9 +177,9 @@ rule norm:
     threads: 1
     shell:
         """
-	export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
         java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic} 1> {log.out} 2> {log.err}
-	touch {output.done}
+        touch {output.done}
         """
 	
 ## Create normalizations for MQ > 30
@@ -198,7 +198,7 @@ rule norm:
     threads: 1
     shell:
         """
-	export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
         java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic} 1> {log.out} 2> {log.err}
-	touch {output.done}
+        touch {output.done}
         """

--- a/workflows/buildHIC
+++ b/workflows/buildHIC
@@ -199,6 +199,6 @@ rule norm:
     shell:
         """
         export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
-        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic} 1> {log.out} 2> {log.err}
+        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic30} 1> {log.out} 2> {log.err}
         touch {output.done}
         """

--- a/workflows/buildHIC
+++ b/workflows/buildHIC
@@ -36,7 +36,7 @@ for key in groups:
 ##### Define rules #####
 rule all:
     input:
-        expand('output/{group}/{group}_inter{ext}', group=groups, ext=['.hic', '_30.hic'])
+        expand('output/{group}/{group}_norm{ext}', group=groups, ext=['_done.txt', '30_done.txt'])
 
 ## Merge all merged_nodups.txt files found in mergeList
 rule mergedNoDups:
@@ -127,11 +127,13 @@ rule hic:
     benchmark:
         'output/{group}/benchmarks/{group}_hic.tsv'
     params:
-        chromSizes = config['chromSizes']
+        chromSizes = config['chromSizes'],
+	javaMem = config['javaMem']
     threads: 1
     shell:
         """
-        ./scripts/juicer_tools pre -s {input.inter} -g {input.hists} -q 1 {input.merged_nodups} {output.hic} {params.chromSizes} 1> {log.out} 2> {log.err}
+	export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar pre -n -s {input.inter} -g {input.hists} -q 1 {input.merged_nodups} {output.hic} {params.chromSizes} 1> {log.out} 2> {log.err}
         """
 
 ## Create Hi-C maps file for MQ > 30
@@ -150,9 +152,53 @@ rule hic30:
     benchmark:
         'output/{group}/benchmarks/{group}_hic30.tsv'
     params:
-        chromSizes = config['chromSizes']
+        chromSizes = config['chromSizes'],
+	javaMem = config['javaMem']
     threads: 1
     shell:
         """
-        ./scripts/juicer_tools pre -s {input.inter30} -g {input.hists30} -q 30 {input.merged_nodups} {output.hic30} {params.chromSizes} 1> {log.out} 2> {log.err}
+	export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar pre -n -s {input.inter30} -g {input.hists30} -q 30 {input.merged_nodups} {output.hic30} {params.chromSizes} 1> {log.out} 2> {log.err}
+        """
+	
+## Create normalizations for MQ > 0
+rule norm:
+    input:
+        hic = rules.hic.output.hic
+    output:
+        done = 'output/{group}/{group}_norm_done.txt'
+    log:
+        err = 'output/{group}/logs/{group}_norm.err',
+        out = 'output/{group}/logs/{group}_norm.out'
+    benchmark:
+        'output/{group}/benchmarks/{group}_norm.tsv'
+    params:
+        javaMem = config['javaMem']
+    threads: 1
+    shell:
+        """
+	export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic} 1> {log.out} 2> {log.err}
+	touch {output.done}
+        """
+	
+## Create normalizations for MQ > 30
+rule norm:
+    input:
+        hic30 = rules.hic30.output.hic30
+    output:
+        done = 'output/{group}/{group}_norm30_done.txt'
+    log:
+        err = 'output/{group}/logs/{group}_norm30.err',
+        out = 'output/{group}/logs/{group}_norm30.out'
+    benchmark:
+        'output/{group}/benchmarks/{group}_norm.tsv'
+    params:
+        javaMem = config['javaMem']
+    threads: 1
+    shell:
+        """
+	export IBM_JAVA_OPTIONS="-Xmx{params.javaMem}m -Xgcthreads1"
+        java -Djava.awt.headless=true -Djava.library.path=/lib64 -Xms{params.javaMem}m -Xmx{params.javaMem}m -jar ./scripts/juicer_tools.jar addNorm {input.hic} 1> {log.out} 2> {log.err}
+	touch {output.done}
         """

--- a/workflows/buildHIC
+++ b/workflows/buildHIC
@@ -183,7 +183,7 @@ rule norm:
         """
 	
 ## Create normalizations for MQ > 30
-rule norm:
+rule norm30:
     input:
         hic30 = rules.hic30.output.hic30
     output:


### PR DESCRIPTION
Added norm rules to buildHIC and alignFASTQ separate from hic/hic30; changed juicer_tools usage to call directly from the .jar with a new "javaMem" config parameter to change the memory allocated for this